### PR TITLE
Add nephkp to the permissions

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -32,6 +32,8 @@ provider:
             - "arn:aws:s3:::dig-bio-index/*"
             - "arn:aws:s3:::dig-giant-sandbox"
             - "arn:aws:s3:::dig-giant-sandbox/*"
+            - "arn:aws:s3:::dig-nephkp"
+            - "arn:aws:s3:::dig-nephkp/*"
         - Effect: Allow
           Action:
             - "secretsmanager:*"


### PR DESCRIPTION
I think this must have been manually modified and when I deployed it a few months ago it rebroke it. This unbreaks it.